### PR TITLE
AV-130: Add APPTIM_CLI_VERSION as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         APPTIM_API_KEY: ${{ secrets.APPTIM_API_KEY }}
         CONFIG_PATH: config.yml 
-        APPTIM_CLI_VERSION: 1.8
+        APPTIM_CLI_VERSION: 1.9
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         APPTIM_API_KEY: ${{ secrets.APPTIM_API_KEY }}
         CONFIG_PATH: config.yml 
+        APPTIM_CLI_VERSION: 1.8
 
 
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir /tmp/apptim-cli
-curl --output /tmp/apptim-cli/cli.zip https://devicefarm.apptim.com/apptim-devicefarm-ubuntu-20.04-1.8.zip
+curl --output /tmp/apptim-cli/cli.zip https://devicefarm.apptim.com/apptim-devicefarm-ubuntu-20.04-${APPTIM_CLI_VERSION}.zip
 unzip /tmp/apptim-cli/cli.zip -d /tmp/apptim-cli
 
 /tmp/apptim-cli/devicefarm run --config ${CONFIG_PATH}


### PR DESCRIPTION
I already tested it using a demo repository. We can see in this screenshot that the action used the 1.8 version set by the other repo .yml
![Screen Shot 2022-01-26 at 20 46 58](https://user-images.githubusercontent.com/23363041/151265795-b97f891c-2df3-4dda-a91b-81d52ce00a77.png)
.